### PR TITLE
Цепочки вызовов https://github.com/vitalSmirnov/refactoring/issues/19

### DIFF
--- a/CloneIntime.csproj
+++ b/CloneIntime.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <!-- ��������� ������������� ����� ����� ������ .NET Runtime -->
@@ -25,12 +25,14 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.3" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+        <PackageReference Include="xunit" Version="2.9.3" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Методы:
вынесение метода, паттерн строител, удаление дублирования

Почему?
До этого цепочки вызовов знали слишком сильно об структуре базы данных и связях в EF, так же метод был слишком длиннный (> 150 строк), сейчас 99. Паттерн строитель был выбран для того, чтобы из методов собирался запрос, в зависимости от нужных данных.. Вынесение метода было выбрано для уменьшения дублирования

Вывод:
Стало меньше кода, он лучше разделен по отдельным методам, что улучшает понимание и читаемость